### PR TITLE
Fix README prerequisites heading

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 
 # Usage
 
-## Prerequisities:
+## Prerequisites:
 
 1. AWS IAM user set up
 2. Configured AWS CLI client (```aws configure```)


### PR DESCRIPTION
## Summary
- fix spelling of `Prerequisites` heading in README

## Testing
- `pre-commit` *(fails: command not found)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_68415462b3dc832c891f09bab2575af4